### PR TITLE
feat!: support `<img>` lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ To customize ready class for an element, pass a string (or string variable) to t
 
 ### Ready class per element
 
-> **Note**: Bg images only
+> **Note**: Bg images only. Per-element classes will always override global.
 
 ```vue
 <template>
@@ -168,8 +168,6 @@ To customize ready class for an element, pass a string (or string variable) to t
   </div>
 </template>
 ```
-
-> **Note**: per-element classes will always override global.
 
 ### Vue Globally
 
@@ -211,9 +209,9 @@ export default defineNuxtPlugin((nuxtApp) => {
 
 There are a few things to take note of:
 
-- When using Vite, you need to pass an absolute or resolved image URL. This is due to Vite's [Static Asset Handling](https://vitejs.dev/guide/assets.html). This doesn't apply to background images, though.
+- When lazy loading `<img>` with Vite, you need to pass an absolute or resolved image URL due to Vite's [Static Asset Handling](https://vitejs.dev/guide/assets.html). This doesn't apply to background images, though.
 - This plugin does not support loading multiple images as in `srcset` or `sources`. To do that use the browser's `loading="lazy"`.
-- On browsers without `IntersectionObserver` support, the images are loaded normally. While it is possible to lazy load using scroll/resize event listeners, it is less efficient and too much of it can lead to a negative impact on performance. From the frying pan into fire.
+- On browsers without `IntersectionObserver` support, the images are loaded normally. While it is possible to lazy load using scroll/resize event listeners, it is less efficient and too much of it can lead to a negative impact on performance. From the frying pan into fire, they say.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ export default defineNuxtPlugin((nuxtApp) => {
 ```
 
 <br>
-M
-<br>
 
 ## License
 

--- a/lib/directives.ts
+++ b/lib/directives.ts
@@ -1,0 +1,62 @@
+import type { Directive } from 'vue';
+import { isString, useIntersectionObserver } from './utils';
+
+function useLazyBg(readyClass?: string) {
+  const directive: Directive = (el: HTMLElement, { value: rClass }) => {
+    const _class = isString(rClass)
+      ? rClass
+      : isString(readyClass)
+        ? readyClass
+        : 'img-ready';
+
+    if (!el || !window)
+      return;
+
+    // we're in the browser, element exists,
+    // and IntersectionObserver is supported
+    if ('IntersectionObserver' in window) {
+      const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
+        if (isIntersecting) {
+          el.classList.add(_class);
+          stop();
+        }
+      });
+    }
+    else {
+      const timeout = setTimeout(() => {
+        el.classList.add(_class);
+        clearTimeout(timeout);
+      }, 0);
+    }
+  };
+
+  return directive;
+}
+
+function useLazyFg() {
+  const directive: Directive = (el: HTMLElement, { value: src }) => {
+    if (!(el && window && isString(src)))
+      return;
+
+    // we're in the browser, element exists, src is valid,
+    // and IntersectionObserver is supported
+    if ('IntersectionObserver' in window) {
+      const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
+        if (isIntersecting) {
+          el.setAttribute('src', src);
+          stop();
+        }
+      });
+    }
+    else {
+      const timeout = setTimeout(() => {
+        el.setAttribute('src', src);
+        clearTimeout(timeout);
+      }, 0);
+    }
+  };
+
+  return directive;
+}
+
+export { useLazyBg, useLazyFg };

--- a/lib/directives.ts
+++ b/lib/directives.ts
@@ -1,62 +1,60 @@
 import type { Directive } from 'vue';
 import { isString, useIntersectionObserver } from './utils';
 
-function useLazyBg(readyClass?: string) {
-  const directive: Directive = (el: HTMLElement, { value: rClass }) => {
-    const _class = isString(rClass)
-      ? rClass
-      : isString(readyClass)
-        ? readyClass
-        : 'img-ready';
+function useLazyPix(defaultClass?: string) {
+  const directive: Directive = (el: HTMLElement, { value: src_or_class, arg }) => {
+    const isBg = arg === 'bg';
 
+    let className = '';
+    let src = '';
+
+    if (isBg) {
+      className = isString(src_or_class)
+        ? src_or_class
+        : isString(defaultClass)
+          ? defaultClass
+          : 'img-ready';
+    }
+    else {
+      src = isString(src_or_class) ? src_or_class : '';
+    }
+
+    // not element or window doesn't exist (SSR)
     if (!el || !window)
       return;
 
-    // we're in the browser, element exists,
-    // and IntersectionObserver is supported
-    if ('IntersectionObserver' in window) {
-      const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
-        if (isIntersecting) {
-          el.classList.add(_class);
-          stop();
-        }
-      });
-    }
-    else {
-      const timeout = setTimeout(() => {
-        el.classList.add(_class);
-        clearTimeout(timeout);
-      }, 0);
-    }
-  };
-
-  return directive;
-}
-
-function useLazyFg() {
-  const directive: Directive = (el: HTMLElement, { value: src }) => {
-    if (!(el && window && isString(src)))
+    // not bg-img but src is not a valid string
+    if (!isBg && !src)
       return;
 
-    // we're in the browser, element exists, src is valid,
-    // and IntersectionObserver is supported
-    if ('IntersectionObserver' in window) {
-      const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
-        if (isIntersecting) {
-          el.setAttribute('src', src);
-          stop();
-        }
-      });
-    }
-    else {
-      const timeout = setTimeout(() => {
+    function startLoading() {
+      if (isBg)
+        el.classList.add(className);
+      else
         el.setAttribute('src', src);
+    }
+
+    // intersection observer not supported
+    if (!('IntersectionObserver' in window)) {
+      const timeout = setTimeout(() => {
+        startLoading();
         clearTimeout(timeout);
       }, 0);
+
+      return;
     }
+
+    // we're in the browser, element exists, src/class is set,
+    // and IntersectionObserver is supported
+    const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
+      if (isIntersecting) {
+        startLoading();
+        stop();
+      }
+    });
   };
 
   return directive;
 }
 
-export { useLazyBg, useLazyFg };
+export { useLazyPix };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,2 @@
 export { vuePlugin as vLazyPix, lazyConfig } from './vue-plugin';
-export { useLazyBg, useLazyFg as useLazyImg } from './directives';
+export { useLazyPix } from './directives';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,2 @@
 export { vuePlugin as vLazyPix } from './vue-plugin';
-export { useLazyPix } from './utils';
+export { useLazyBg, useLazyFg as useLazyImg } from './directives';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,2 @@
-export { vuePlugin as vLazyPix } from './vue-plugin';
+export { vuePlugin as vLazyPix, lazyConfig } from './vue-plugin';
 export { useLazyBg, useLazyFg as useLazyImg } from './directives';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -28,9 +28,9 @@ function useIntersectionObserver(
 }
 
 function useLazyPix(readyClass?: string) {
-  const directive: Directive = (el: HTMLElement, binding) => {
-    const _class = isString(binding.value)
-      ? binding.value
+  const directive: Directive = (el: HTMLElement, { value: rClass }) => {
+    const _class = isString(rClass)
+      ? rClass
       : isString(readyClass)
         ? readyClass
         : 'img-ready';
@@ -38,7 +38,7 @@ function useLazyPix(readyClass?: string) {
     if (!el || !window)
       return;
 
-    // we're in the browser and element exists
+    // we're in the browser, element exists,
     // and IntersectionObserver is supported
     if ('IntersectionObserver' in window) {
       const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
@@ -49,7 +49,36 @@ function useLazyPix(readyClass?: string) {
       });
     }
     else {
-      el.classList.add(_class);
+      const timeout = setTimeout(() => {
+        el.classList.add(_class);
+        clearTimeout(timeout);
+      }, 0);
+    }
+  };
+
+  return directive;
+}
+
+function useLazyImg() {
+  const directive: Directive = (el: HTMLElement, { value: src }) => {
+    if (!(el && window && isString(src)))
+      return;
+
+    // we're in the browser, element exists, src is valid,
+    // and IntersectionObserver is supported
+    if ('IntersectionObserver' in window) {
+      const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
+        if (isIntersecting) {
+          el.setAttribute('src', src);
+          stop();
+        }
+      });
+    }
+    else {
+      const timeout = setTimeout(() => {
+        el.setAttribute('src', src);
+        clearTimeout(timeout);
+      }, 0);
     }
   };
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -18,8 +18,8 @@ function useIntersectionObserver(
   let observer: IntersectionObserver | null;
 
   observer = new IntersectionObserver(callback, {
-    rootMargin: '0px',
-    threshold: 0.1,
+    rootMargin: '100px',
+    threshold: 0,
   });
 
   observer.observe(target);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,10 +7,6 @@ function removePrefix(str: string) {
   return str.replace(/^v-/, '');
 }
 
-function isObject(obj: unknown): obj is object {
-  return typeof obj === 'object' && obj !== null;
-}
-
 function useIntersectionObserver(
   target: Element,
   callback: IntersectionObserverCallback,
@@ -34,4 +30,4 @@ function useIntersectionObserver(
   return stop;
 }
 
-export { isString, isObject, removePrefix, useIntersectionObserver };
+export { isString, removePrefix, useIntersectionObserver };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,14 @@
-import type { Directive } from 'vue';
-
 function isString(str: any): str is string {
   return typeof str === 'string' && str !== '';
+}
+
+function removePrefix(str: string) {
+  // remove possible 'v-' prefix
+  return str.replace(/^v-/, '');
+}
+
+function isObject(obj: any): obj is object {
+  return obj && typeof obj === 'object';
 }
 
 function useIntersectionObserver(
@@ -27,62 +34,4 @@ function useIntersectionObserver(
   return stop;
 }
 
-function useLazyPix(readyClass?: string) {
-  const directive: Directive = (el: HTMLElement, { value: rClass }) => {
-    const _class = isString(rClass)
-      ? rClass
-      : isString(readyClass)
-        ? readyClass
-        : 'img-ready';
-
-    if (!el || !window)
-      return;
-
-    // we're in the browser, element exists,
-    // and IntersectionObserver is supported
-    if ('IntersectionObserver' in window) {
-      const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
-        if (isIntersecting) {
-          el.classList.add(_class);
-          stop();
-        }
-      });
-    }
-    else {
-      const timeout = setTimeout(() => {
-        el.classList.add(_class);
-        clearTimeout(timeout);
-      }, 0);
-    }
-  };
-
-  return directive;
-}
-
-function useLazyImg() {
-  const directive: Directive = (el: HTMLElement, { value: src }) => {
-    if (!(el && window && isString(src)))
-      return;
-
-    // we're in the browser, element exists, src is valid,
-    // and IntersectionObserver is supported
-    if ('IntersectionObserver' in window) {
-      const stop = useIntersectionObserver(el, ([{ isIntersecting }]) => {
-        if (isIntersecting) {
-          el.setAttribute('src', src);
-          stop();
-        }
-      });
-    }
-    else {
-      const timeout = setTimeout(() => {
-        el.setAttribute('src', src);
-        clearTimeout(timeout);
-      }, 0);
-    }
-  };
-
-  return directive;
-}
-
-export { isString, useLazyPix };
+export { isString, isObject, removePrefix, useIntersectionObserver };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-function isString(str: any): str is string {
+function isString(str: unknown): str is string {
   return typeof str === 'string' && str !== '';
 }
 
@@ -7,8 +7,8 @@ function removePrefix(str: string) {
   return str.replace(/^v-/, '');
 }
 
-function isObject(obj: any): obj is object {
-  return obj && typeof obj === 'object';
+function isObject(obj: unknown): obj is object {
+  return typeof obj === 'object' && obj !== null;
 }
 
 function useIntersectionObserver(

--- a/lib/vue-plugin.ts
+++ b/lib/vue-plugin.ts
@@ -1,47 +1,20 @@
 import type { Plugin } from 'vue';
-import { isObject, isString, removePrefix } from './utils';
-import { useLazyBg, useLazyFg } from './directives';
+import { isString, removePrefix } from './utils';
+import { useLazyPix } from './directives';
 
 interface PluginOptions {
   /**
-   * Configure `v-lazy-bg` options
+   * Change directive name
+   * @hey don't prefix with 'v-'
+   * @default 'lazy-pix' => 'v-lazy-pix'
    */
-  bg?: {
-    /**
-     * Change directive name (global)
-     * @hey don't prefix with 'v-'
-     * @default 'lazy-bg'
-     */
-    name?: string
-    /**
-     * Change ready class (global)
-     * @default 'img-ready'
-     */
-    class?: string
-    /**
-     * Whether to disable to enable the directive
-     * @default false
-     */
-    disabled?: boolean
-  }
-
+  name?: string
   /**
-   * Configure `v-lazy-img` options
+   * Change default ready class for background images
+   * (global)
+   * @default 'img-ready'
    */
-  img?: {
-    /**
-     * Change directive name (global)
-     * @hey don't prefix with 'v-'
-     * @default 'lazy-img'
-     */
-    name?: string
-
-    /**
-     * Whether to disable to enable the directive
-     * @default false
-     */
-    disabled?: boolean
-  }
+  class?: string
 }
 
 function lazyConfig(options: PluginOptions = {}): PluginOptions {
@@ -50,24 +23,16 @@ function lazyConfig(options: PluginOptions = {}): PluginOptions {
 
 const vuePlugin: Plugin = {
   install: (app, options: PluginOptions = {}) => {
-    let bg: typeof options.bg = {};
-    let fg: typeof options.img = {};
+    let dName: typeof options.name;
+    let dClass: typeof options.class;
 
-    if (isObject(options)) {
-      bg = isObject(options.bg) ? options.bg : {};
-      fg = isObject(options.img) ? options.img : {};
+    if (typeof options === 'object' && options !== null) {
+      dName = options.name;
+      dClass = options.class;
     }
 
-    // app.directive(name, directive);
-
-    if (!bg.disabled) {
-      const bgName = isString(bg.name) ? removePrefix(bg.name) : 'lazy-bg';
-      app.directive(bgName, useLazyBg(bg.class));
-    }
-    if (!fg.disabled) {
-      const fgName = isString(fg.name) ? removePrefix(fg.name) : 'lazy-img';
-      app.directive(fgName, useLazyFg());
-    }
+    const directiveName = isString(dName) ? removePrefix(dName) : 'lazy-pix';
+    app.directive(directiveName, useLazyPix(dClass));
   },
 };
 

--- a/lib/vue-plugin.ts
+++ b/lib/vue-plugin.ts
@@ -32,7 +32,7 @@ interface PluginOptions {
     /**
      * Change directive name (global)
      * @hey don't prefix with 'v-'
-     * @default 'v-lazy-img'
+     * @default 'lazy-img'
      */
     name?: string
 

--- a/lib/vue-plugin.ts
+++ b/lib/vue-plugin.ts
@@ -15,7 +15,7 @@ interface PluginOptions {
     name?: string
     /**
      * Change ready class (global)
-     * @default 'ready-img'
+     * @default 'img-ready'
      */
     class?: string
     /**

--- a/lib/vue-plugin.ts
+++ b/lib/vue-plugin.ts
@@ -1,32 +1,74 @@
 import type { Plugin } from 'vue';
-import { isString, useLazyPix } from './utils';
+import { isObject, isString, removePrefix } from './utils';
+import { useLazyBg, useLazyFg } from './directives';
 
 interface PluginOptions {
   /**
-   * Globally change directive name
+   * Configure `v-lazy-bg` options
    */
-  name?: string
+  bg?: {
+    /**
+     * Change directive name (global)
+     * @hey don't prefix with 'v-'
+     * @default 'lazy-bg'
+     */
+    name?: string
+    /**
+     * Change ready class (global)
+     * @default 'ready-img'
+     */
+    class?: string
+    /**
+     * Whether to disable to enable the directive
+     * @default false
+     */
+    disabled?: boolean
+  }
+
   /**
-   * Globally change ready-class
+   * Configure `v-lazy-img` options
    */
-  class?: string
+  img?: {
+    /**
+     * Change directive name (global)
+     * @hey don't prefix with 'v-'
+     * @default 'v-lazy-img'
+     */
+    name?: string
+
+    /**
+     * Whether to disable to enable the directive
+     * @default false
+     */
+    disabled?: boolean
+  }
+}
+
+function lazyConfig(options: PluginOptions = {}): PluginOptions {
+  return options;
 }
 
 const vuePlugin: Plugin = {
   install: (app, options: PluginOptions = {}) => {
-    // c-ustom name and ready-class
-    let cName, cReady;
-    if (options && typeof options === 'object') {
-      cName = options.name;
-      cReady = options.class;
+    let bg: typeof options.bg = {};
+    let fg: typeof options.img = {};
+
+    if (isObject(options)) {
+      bg = isObject(options.bg) ? options.bg : {};
+      fg = isObject(options.img) ? options.img : {};
     }
 
-    const name = isString(cName) ? cName : 'lazy-pix';
-
-    // const directive = useLazyPix(cReady);
     // app.directive(name, directive);
-    app.directive(name, useLazyPix(cReady));
+
+    if (!bg.disabled) {
+      const bgName = isString(bg.name) ? removePrefix(bg.name) : 'lazy-bg';
+      app.directive(bgName, useLazyBg(bg.class));
+    }
+    if (!fg.disabled) {
+      const fgName = isString(fg.name) ? removePrefix(fg.name) : 'lazy-img';
+      app.directive(fgName, useLazyFg());
+    }
   },
 };
 
-export { vuePlugin };
+export { vuePlugin, lazyConfig };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lazy-pix",
   "type": "module",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "private": false,
   "packageManager": "pnpm@7.22.0",
   "description": "Simple Vue plugin to lazy-load background images",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0-beta.3",
   "private": false,
   "packageManager": "pnpm@7.22.0",
-  "description": "Simple Vue plugin to lazy-load background images",
+  "description": "Simple Vue and Nuxt plugin to lazy-load images",
   "author": "Moses Laurence<me.mlaure@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/ijkml/lazy-pix#readme",
@@ -20,7 +20,8 @@
     "nuxt-image",
     "vue-image",
     "lazy-bg",
-    "lazy-image"
+    "lazy-image",
+    "lazy-img"
   ],
   "sideEffects": false,
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lazy-pix",
   "type": "module",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "private": false,
   "packageManager": "pnpm@7.22.0",
   "description": "Simple Vue plugin to lazy-load background images",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lazy-pix",
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": false,
   "packageManager": "pnpm@7.22.0",
   "description": "Simple Vue plugin to lazy-load background images",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lazy-pix",
   "type": "module",
-  "version": "0.1.0",
+  "version": "1.0.0-beta.0",
   "private": false,
   "packageManager": "pnpm@7.22.0",
   "description": "Simple Vue plugin to lazy-load background images",
@@ -50,7 +50,8 @@
     "lint": "eslint .",
     "lintf": "eslint . --fix",
     "typecheck": "vue-tsc --noEmit",
-    "release": "bumpp && npm publish --access=public"
+    "release": "bumpp && npm publish --access=public",
+    "release:beta": "bumpp && npm publish --tag beta --access=public"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.34.0",


### PR DESCRIPTION
Breaking changes:
- `v-lazy-pix` defaults to `<img>`
- use `v-lazy-pix:bg` for background images

New Features:
- silent "do nothing" fallback in case `IntersectionObserver` is not supported
- add `lazyConfig()` to provide types & intellisense when configuring plugin